### PR TITLE
fix: directory madness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 backend/venv
+backend/currentplugin
 backend/wordpress/currentplugin
 backend/__pycache__
+backend/wordpress/__pycache__
 backend/wordpress/CHKPLUG

--- a/backend/wordpress/webpress.py
+++ b/backend/wordpress/webpress.py
@@ -56,7 +56,8 @@ def get_download(plugin: str) -> str:
 def download_unzip(url: str) -> None:
     req = requests.get(url, stream=True)
     zf = zipfile.ZipFile(BytesIO(req.content))
-    shutil.rmtree("currentplugin")
+    if os.path.exists("currentplugin"):
+        shutil.rmtree("currentplugin")
     zf.extractall(path="currentplugin")
     zf.close()    
     tbc = os.listdir("currentplugin")[0]


### PR DESCRIPTION
Fixes
- On my machine&trade; `__pycache__` and `currentplugin` are created one directory level higher than what the gitignore expects
- `shutil.rmtree("currentplugin")` being called even if that directory doesn't exist (ie when executing from a clean checkout)
 
